### PR TITLE
black formatting for quantum.py

### DIFF
--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Differentiable quantum functions"""
 import functools
+
 # pylint: disable=import-outside-toplevel
 import itertools
 from string import ascii_letters as ABC
@@ -99,7 +100,7 @@ def cov_matrix(prob, obs, wires=None, diag_approx=False):
         w = o.wires.labels if wires is None else wires.indices(o.wires)
         p = marginal_prob(prob, w)
 
-        res = dot(eigvals ** 2, p) - (dot(eigvals, p)) ** 2
+        res = dot(eigvals**2, p) - (dot(eigvals, p)) ** 2
         variances.append(res)
 
     cov = diag(variances)
@@ -295,7 +296,7 @@ def batched_partial_trace(matrix, indices, c_dtype="complex128"):
     # For loop over wires
     for i, target_index in enumerate(indices):
         target_index = target_index - i
-        state_indices = ABC[1: rho_dim - 2 * i + 1]
+        state_indices = ABC[1 : rho_dim - 2 * i + 1]
         state_indices = list(state_indices)
 
         target_letter = state_indices[target_index]
@@ -307,7 +308,7 @@ def batched_partial_trace(matrix, indices, c_dtype="complex128"):
 
     number_wires_sub = num_indices - len(indices)
     reduced_density_matrix = np.reshape(
-        matrix, (batch_dim, 2 ** number_wires_sub, 2 ** number_wires_sub)
+        matrix, (batch_dim, 2**number_wires_sub, 2**number_wires_sub)
     )
     return reduced_density_matrix
 
@@ -332,7 +333,7 @@ def _batched_partial_trace_nonrep_indices(matrix, indices):
     # For loop over wires
     for target_wire in indices:
         # Tensor indices of density matrix
-        state_indices = ABC[1: rho_dim + 1]
+        state_indices = ABC[1 : rho_dim + 1]
         # row indices of the quantum state affected by this operation
         row_wires_list = [target_wire + 1]
         row_indices = "".join(ABC_ARRAY[row_wires_list].tolist())
@@ -341,14 +342,14 @@ def _batched_partial_trace_nonrep_indices(matrix, indices):
         col_indices = "".join(ABC_ARRAY[col_wires_list].tolist())
         # indices in einsum must be replaced with new ones
         num_partial_trace_wires = 1
-        new_row_indices = ABC[rho_dim + 1: rho_dim + num_partial_trace_wires + 1]
+        new_row_indices = ABC[rho_dim + 1 : rho_dim + num_partial_trace_wires + 1]
         new_col_indices = ABC[
-                          rho_dim + num_partial_trace_wires + 1: rho_dim + 2 * num_partial_trace_wires + 1
-                          ]
+            rho_dim + num_partial_trace_wires + 1 : rho_dim + 2 * num_partial_trace_wires + 1
+        ]
         # index for summation over Kraus operators
         kraus_index = ABC[
-                      rho_dim + 2 * num_partial_trace_wires + 1: rho_dim + 2 * num_partial_trace_wires + 2
-                      ]
+            rho_dim + 2 * num_partial_trace_wires + 1 : rho_dim + 2 * num_partial_trace_wires + 2
+        ]
         # new state indices replace row and column indices with new ones
         new_state_indices = functools.reduce(
             lambda old_string, idx_pair: old_string.replace(idx_pair[0], idx_pair[1]),
@@ -364,7 +365,7 @@ def _batched_partial_trace_nonrep_indices(matrix, indices):
 
     number_wires_sub = num_indices - len(indices)
     reduced_density_matrix = np.reshape(
-        matrix, (batch_dim, 2 ** number_wires_sub, 2 ** number_wires_sub)
+        matrix, (batch_dim, 2**number_wires_sub, 2**number_wires_sub)
     )
     return reduced_density_matrix
 
@@ -441,7 +442,7 @@ def reduce_statevector(state, indices, check_state=False, c_dtype="complex128"):
     # traced_system = [x + 1 for x in consecutive_wires if x not in indices]
 
     # trace out the subsystem
-    indices1 = ABC[1: num_wires + 1]
+    indices1 = ABC[1 : num_wires + 1]
     indices2 = "".join(
         [ABC[num_wires + i + 1] if i in indices else ABC[i + 1] for i in consecutive_wires]
     )
@@ -702,7 +703,7 @@ def mutual_info(state, indices0, indices1, base=None, check_state=False, c_dtype
 
 # pylint: disable=too-many-arguments
 def _compute_mutual_info(
-        state, indices0, indices1, base=None, check_state=False, c_dtype="complex128"
+    state, indices0, indices1, base=None, check_state=False, c_dtype="complex128"
 ):
     """Compute the mutual information between the subsystems."""
     all_indices = sorted([*indices0, *indices1])
@@ -874,9 +875,9 @@ def _check_density_matrix(density_matrix):
     """Check the shape, the trace and the positive semi-definitiveness of a matrix."""
     dim = density_matrix.shape[-1]
     if (
-            len(density_matrix.shape) not in (2, 3)
-            or density_matrix.shape[-2] != dim
-            or not np.log2(dim).is_integer()
+        len(density_matrix.shape) not in (2, 3)
+        or density_matrix.shape[-2] != dim
+        or not np.log2(dim).is_integer()
     ):
         raise ValueError("Density matrix must be of shape (2**N, 2**N) or (batch_dim, 2**N, 2**N).")
 


### PR DESCRIPTION
style: format spacing and exponentiation in quantum.py

- Add blank line for better separation of imports and module docstring.
- Adjust spacing around colons for slice notation to follow PEP 8 style guidelines.
- Standardize exponentiation operator spacing for consistency and readability.
