### PR TITLE
black formatting for test_matrix_manipulation.py

### DIFF
--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -244,7 +244,6 @@ class TestExpandMatrix:
         """Tests differentiation in TensorFlow by computing the Jacobian of
         the expanded matrix with respect to the canonical matrix."""
 
-
         base_matrix = tf.Variable(base_matrix)
         with tf.GradientTape() as tape:
             res = self.func_for_autodiff(base_matrix)


### PR DESCRIPTION
black formatting remove redundant newline in test_matrix_manipulation

Removed an unnecessary blank line from the TestExpandMatrix class in test_matrix_manipulation.py to improve code readability and maintain consistency. This change does not affect the test functionality but adheres to the coding style guidelines.