### PR TITLE
fix unit test errors by adding custom dtype support for batched_partial trace

### DIFF
--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -237,7 +237,7 @@ def reduce_dm(density_matrix, indices, check_state=False, c_dtype="complex128"):
 
     # Compute the partial trace
     traced_wires = [x for x in consecutive_indices if x not in indices]
-    density_matrix = batched_partial_trace(density_matrix, traced_wires)
+    density_matrix = batched_partial_trace(density_matrix, traced_wires, c_dtype=c_dtype)
 
     if batch_dim is None:
         density_matrix = density_matrix[0]


### PR DESCRIPTION
updates the reduce_dm function in the quantum.py module to allow custom data types (dtype) when calling the batched_partial_trace function. Previously, the dtype was hardcoded, but now users can specify the dtype, enhancing flexibility for different computational requirements.