### PR TITLE
Further updates

### DIFF
--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -261,17 +261,15 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
 
     **Example**
     >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
-    ...
     >>> partial_trace(x, indices=[0])
     array([[1, 0], [0, 0]])
 
     >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
-    ...
     >>> partial_trace(x, indices=[0])
     array([[1, 0], [0, 0]])
 
     >>> x = np.array([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
-    ...               [[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]])
+                     [[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]])
     >>> partial_trace(x, indices=[0])
     array([[[1, 0],
             [0, 0]],
@@ -280,8 +278,8 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
             [0, 1]]])
 
     >>> x = tf.Variable([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
-    ...                  [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]]], dtype=tf.complex128)
-    >>> batched_partial_trace(x, indices=[1])
+                        [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]]], dtype=tf.complex128)
+    >>> partial_trace(x, indices=[1])
     <tf.Tensor: shape=(2, 2, 2), dtype=complex128, numpy=
     array([[[1.+0.j, 0.+0.j],
             [0.+0.j, 0.+0.j]],

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -22,6 +22,7 @@ from autoray import numpy as np
 from numpy import float64
 
 import pennylane as qml
+from . import single_dispatch  # pylint:disable=unused-import
 from .matrix_manipulation import _permute_dense_matrix
 from .multi_dispatch import diag, dot, scatter_element_add, einsum, get_interface
 from .utils import is_abstract, allclose, cast, convert_like, cast_like

--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -912,6 +912,7 @@ class TestPartialTrace:
     @pytest.mark.parametrize("c_dtype", dtypes)
     def test_invalid_wire_selection(self, ml_framework, c_dtype):
         """Test that an error is raised for an invalid wire selection."""
+        import tensorflow as tf
         # Define a 2-qubit density matrix
         rho = qml.math.asarray(
             np.array([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]]), like=ml_framework

--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -22,7 +22,7 @@ from scipy.sparse import csr_matrix
 import pennylane as qml
 from pennylane import numpy as pnp
 
-
+tf = pytest.importorskip("tensorflow", minversion="2.1")
 
 # Define a list of dtypes to test
 dtypes = ["complex64", "complex128"]
@@ -912,7 +912,6 @@ class TestPartialTrace:
     @pytest.mark.parametrize("c_dtype", dtypes)
     def test_invalid_wire_selection(self, ml_framework, c_dtype):
         """Test that an error is raised for an invalid wire selection."""
-        import tensorflow as tf
         # Define a 2-qubit density matrix
         rho = qml.math.asarray(
             np.array([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]]), like=ml_framework

--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -22,10 +22,7 @@ from scipy.sparse import csr_matrix
 import pennylane as qml
 from pennylane import numpy as pnp
 
-tf = pytest.importorskip("tensorflow", minversion="2.1")
-torch = pytest.importorskip("torch")
-jax = pytest.importorskip("jax")
-jnp = pytest.importorskip("jax.numpy")
+
 
 # Define a list of dtypes to test
 dtypes = ["complex64", "complex128"]
@@ -212,6 +209,7 @@ class TestExpandMatrix:
     def test_torch(self, i, base_matrix, tol):
         """Tests differentiation in torch by computing the Jacobian of
         the expanded matrix with respect to the canonical matrix."""
+        import torch
 
         base_matrix = torch.tensor(base_matrix, requires_grad=True)
         jac = torch.autograd.functional.jacobian(self.func_for_autodiff, base_matrix)
@@ -229,6 +227,7 @@ class TestExpandMatrix:
     def test_jax(self, i, base_matrix, tol):
         """Tests differentiation in jax by computing the Jacobian of
         the expanded matrix with respect to the canonical matrix."""
+        import jax
 
         base_matrix = jax.numpy.array(base_matrix)
         jac_fn = jax.jacobian(self.func_for_autodiff)
@@ -247,6 +246,7 @@ class TestExpandMatrix:
     def test_tf(self, i, base_matrix, tol):
         """Tests differentiation in TensorFlow by computing the Jacobian of
         the expanded matrix with respect to the canonical matrix."""
+        import tensorflow as tf
 
         base_matrix = tf.Variable(base_matrix)
         with tf.GradientTape() as tape:
@@ -857,7 +857,7 @@ class TestPartialTrace:
 
         # Perform the partial trace
         result = qml.math.quantum.partial_trace(rho, [0], c_dtype=c_dtype)
-        assert np.allclose(result, expected)
+        assert qml.math.allclose(result, expected)
 
     @pytest.mark.parametrize("c_dtype", dtypes)
     def test_batched_density_matrices(self, ml_framework, c_dtype):
@@ -881,7 +881,7 @@ class TestPartialTrace:
 
         # Perform the partial trace
         result = qml.math.quantum.partial_trace(rho, [1], c_dtype=c_dtype)
-        assert np.allclose(result, expected)
+        assert qml.math.allclose(result, expected)
 
     @pytest.mark.parametrize("c_dtype", dtypes)
     def test_partial_trace_over_no_wires(self, ml_framework, c_dtype):
@@ -893,7 +893,7 @@ class TestPartialTrace:
 
         # Perform the partial trace over no wires
         result = qml.math.quantum.partial_trace(rho, [], c_dtype=c_dtype)
-        assert np.allclose(result, rho)
+        assert qml.math.allclose(result, rho)
 
     @pytest.mark.parametrize("c_dtype", dtypes)
     def test_partial_trace_over_all_wires(self, ml_framework, c_dtype):
@@ -907,7 +907,7 @@ class TestPartialTrace:
 
         # Perform the partial trace over all wires
         result = qml.math.quantum.partial_trace(rho, [0, 1], c_dtype=c_dtype)
-        assert np.allclose(result, expected)
+        assert qml.math.allclose(result, expected)
 
     @pytest.mark.parametrize("c_dtype", dtypes)
     def test_invalid_wire_selection(self, ml_framework, c_dtype):
@@ -937,4 +937,4 @@ class TestPartialTrace:
         result = qml.math.quantum.partial_trace(rho, [0], c_dtype=c_dtype)
         expected = qml.math.asarray(np.array([[1, 0], [0, 0]]), like=ml_framework)
 
-        assert np.allclose(result, expected)
+        assert qml.math.allclose(result, expected)


### PR DESCRIPTION
- added tf = pytest.importorskip("tensorflow", minversion="2.1") to fix errors in unit tests
- removed internal tf import in test_invalid_wire_selection so that test would reference above tf instantiation 