### PR TITLE
Refactor DummyOp in test_matrix_manipulation.py

### DIFF
--- a/tests/math/test_matrix_manipulation.py
+++ b/tests/math/test_matrix_manipulation.py
@@ -500,10 +500,8 @@ class TestExpandMatrix:
 
             num_wires = 2
 
-            # pylint: disable=arguments-differ
             @staticmethod
             def compute_matrix():
-                """Compute the matrix of the DummyOp."""
                 return self.base_matrix_2
 
         op = DummyOp(wires=[0, 2])


### PR DESCRIPTION
This pull request includes a small refactor in the `test_matrix_manipulation.py` file, specifically within the `TestExpandMatrix` class. The changes are as follows:

- Removed the `pylint` disable comment for `arguments-differ`. This change suggests that the method signature now complies with the expected interface, and there is no longer a need to disable the pylint check for differing arguments.
- Removed the docstring for the `compute_matrix` static method. This could indicate that the method's purpose is self-explanatory or that the docstring was deemed unnecessary.

These changes should not affect the functionality of the tests but rather clean up the code for better readability and maintenance.

Please review the changes to ensure that the removal of the pylint disable comment and the docstring align with our coding standards and documentation practices.
