### PR TITLE
Fix partial_trace return behavior for non-batched inputs

### DIFF
--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -261,7 +261,7 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
         tensor_like: (reduced) Density matrix of size ``(2**len(wires), 2**len(wires))``
 
     **Example**
-    
+
     We can compute the partial trace of the matrix ``x`` with respect to its first index.
     >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
     >>> partial_trace(x, indices=[0])
@@ -296,7 +296,6 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
         is_batched = True
         batch_dim, dim = matrix.shape[:2]
 
-
     if get_interface(matrix) in ["autograd", "tensorflow"]:
         return _batched_partial_trace_nonrep_indices(matrix, indices, batch_dim, dim)
 
@@ -324,7 +323,7 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
     reduced_density_matrix = np.reshape(
         matrix, (batch_dim, 2**number_wires_sub, 2**number_wires_sub)
     )
-    return reduced_density_matrix
+    return reduced_density_matrix if is_batched else reduced_density_matrix[0]
 
 
 def _batched_partial_trace_nonrep_indices(matrix, indices, batch_dim, dim):

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -187,7 +187,6 @@ def reduce_dm(density_matrix, indices, check_state=False, c_dtype="complex128"):
     .. seealso:: :func:`pennylane.math.reduce_statevector`, and :func:`pennylane.density_matrix`
 
     **Example**
-
     >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
     >>> reduce_dm(x, indices=[0])
     [[1.+0.j 0.+0.j]

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -187,6 +187,7 @@ def reduce_dm(density_matrix, indices, check_state=False, c_dtype="complex128"):
     .. seealso:: :func:`pennylane.math.reduce_statevector`, and :func:`pennylane.density_matrix`
 
     **Example**
+
     >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
     >>> reduce_dm(x, indices=[0])
     [[1.+0.j 0.+0.j]
@@ -294,6 +295,7 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
     else:
         is_batched = True
         batch_dim, dim = matrix.shape[:2]
+
 
     if get_interface(matrix) in ["autograd", "tensorflow"]:
         return _batched_partial_trace_nonrep_indices(matrix, indices, batch_dim, dim)


### PR DESCRIPTION
### Summary
This pull request introduces a fix to the `partial_trace` function in the `pennylane/math/quantum.py` module. The change ensures that when the function is called without batched inputs, it returns a single density matrix rather than a batched array with a single element.

### Changes
- Removed an unnecessary whitespace change that did not affect functionality.
- Modified the return statement of the `partial_trace` function to conditionally return the first element of the `reduced_density_matrix` if the input is not batched.

### Example
Previously, calling `partial_trace` with a non-batched input would still return a batched array structure. After this change, the function will return a single density matrix for non-batched inputs, which is more intuitive and convenient for users who are working with individual quantum states.

### Impact
This change improves the usability of the `partial_trace` function and aligns its behavior with the expected output for non-batched inputs. It should not affect any existing code that relies on batched inputs, as the behavior in the batched case remains unchanged.

### Tests
The existing tests should be reviewed to ensure they cover both batched and non-batched scenarios. If necessary, additional tests should be added to validate the new behavior for non-batched inputs.

Please review the changes and let me know if any further adjustments are required.
