### PR TITLE
Clean up whitespace in partial_trace function

### DIFF
--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -261,7 +261,7 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
         tensor_like: (reduced) Density matrix of size ``(2**len(wires), 2**len(wires))``
 
     **Example**
-    
+
     We can compute the partial trace of the matrix ``x`` with respect to its first index.
     >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
     >>> partial_trace(x, indices=[0])
@@ -295,7 +295,6 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
     else:
         is_batched = True
         batch_dim, dim = matrix.shape[:2]
-
 
     if get_interface(matrix) in ["autograd", "tensorflow"]:
         return _batched_partial_trace_nonrep_indices(matrix, indices, batch_dim, dim)


### PR DESCRIPTION
### Summary
This pull request removes unnecessary whitespace and an empty line in the `partial_trace` function within the `quantum.py` file.

### Changes
- Removed an extraneous empty line after the function's example block.
- Removed an unnecessary empty line within the function's logic.

### Context
The removal of these whitespaces contributes to the code's cleanliness and readability, aligning with best practices for code maintenance.

### Testing
No functional changes were made to the code, so existing tests should suffice to ensure that no behavior has been altered.

### Additional Notes
This is a minor aesthetic change and does not impact the functionality of the `partial_trace` function.
