### PR TITLE
docs(quantum): update code block language in docstrings from python3 …

### DIFF
--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -263,12 +263,12 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
     **Example**
 
     We can compute the partial trace of the matrix ``x`` with respect to its 0th index.
-    .. code-block:: python3
+    .. code-block:: python
         >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
         >>> partial_trace(x, indices=[0])
         array([[1, 0], [0, 0]])
     We can also pass a batch of matrices ``x`` to the function and return the partial trace of each matrix with respect to each matrix's 0th index.
-    .. code-block:: python3
+    .. code-block:: python
         >>> x = np.array([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
                         [[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]])
         >>> partial_trace(x, indices=[0])
@@ -278,10 +278,10 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
             [[0, 0],
                 [0, 1]]])
     The partial trace can also be computed with respect to multiple indices within different frameworks such as TensorFlow and PyTorch.
-    .. code-block:: python3
+    .. code-block:: python
         >>> x = tf.Variable([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
                             [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]]], dtype=tf.complex128)
-    .. code-block:: python3
+    .. code-block:: python
         >>> partial_trace(x, indices=[1])
         <tf.Tensor: shape=(2, 2, 2), dtype=complex128, numpy=
         array([[[1.+0.j, 0.+0.j],


### PR DESCRIPTION
### Summary
This pull request updates the language tags in the code block documentation from `python3` to `python`. This change ensures consistency and compatibility with documentation rendering tools that may not recognize `python3` as a valid language identifier.

### Changes
- Changed code block tags from `.. code-block:: python3` to `.. code-block:: python` in the `pennylane/math/quantum.py` file.

### Context
The `partial_trace` function's examples in the documentation were previously marked with `python3` language tags. While this is a valid language identifier, some documentation systems prefer the more general `python` tag. This change should not affect the execution of the code but will ensure better compatibility with various markdown renderers and documentation systems.

### Testing
No code execution is affected by this change; therefore, no additional tests are required. The documentation should be reviewed to ensure that it renders correctly with the updated language tags.

### Documentation
The documentation comments within the code have been updated accordingly. No further documentation changes are necessary.

Please review the changes and let me know if any further modifications are required.

Thank you!
