### PR TITLE
adding whitespace before REPL

### DIFF
--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -264,11 +264,13 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
 
     We can compute the partial trace of the matrix ``x`` with respect to its 0th index.
     .. code-block:: python
+        
         >>> x = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
         >>> partial_trace(x, indices=[0])
         array([[1, 0], [0, 0]])
     We can also pass a batch of matrices ``x`` to the function and return the partial trace of each matrix with respect to each matrix's 0th index.
     .. code-block:: python
+        
         >>> x = np.array([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
                         [[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]])
         >>> partial_trace(x, indices=[0])
@@ -280,9 +282,11 @@ def partial_trace(matrix, indices, c_dtype="complex128"):
 
     The partial trace can also be computed with respect to multiple indices within different frameworks such as TensorFlow and PyTorch.
     .. code-block:: python
+        
         >>> x = tf.Variable([[[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
                             [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]]], dtype=tf.complex128)
     .. code-block:: python
+        
         >>> partial_trace(x, indices=[1])
         <tf.Tensor: shape=(2, 2, 2), dtype=complex128, numpy=
         array([[[1.+0.j, 0.+0.j],


### PR DESCRIPTION
adding whitespace before repl, ran black and pylint after adding the whitespace and both ran correctly 
![Screenshot 2024-02-16 at 6 44 47 PM](https://github.com/babcockt18/pennylane/assets/39506616/d33b60b7-29a2-4e7b-afa2-8424d719d3fd)
